### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/test/apache-types_includer.dart
+++ b/test/apache-types_includer.dart
@@ -18,7 +18,7 @@ main() {
     return request.close();
   }).then((HttpClientResponse response) {
     // Process the response.
-    response.transform(utf8.decoder).listen((bodyChunk) {
+    response.cast<List<int>>().transform(utf8.decoder).listen((bodyChunk) {
       bodyStr = bodyStr + bodyChunk;
     }, onDone: () {
       // handle data


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900