### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/test/apache-types_includer.dart
+++ b/test/apache-types_includer.dart
@@ -18,7 +18,7 @@ main() {
     return request.close();
   }).then((HttpClientResponse response) {
     // Process the response.
-    response.cast<List<int>>().transform(utf8.decoder).listen((bodyChunk) {
+    utf8.decoder.bind(response).listen((bodyChunk) {
       bodyStr = bodyStr + bodyChunk;
     }, onDone: () {
       // handle data


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
