### PR TITLE
Update mime_type.dart to report "mjs" as application/javascript

### DIFF
--- a/lib/mime_type.dart
+++ b/lib/mime_type.dart
@@ -517,6 +517,7 @@ const Map<String, String> _mimeMap = <String, String>{
   'mime': 'message/rfc822',
   'mj2': 'video/mj2',
   'mjp2': 'video/mj2',
+  'mjs': 'application/javascript',
   'mk3d': 'video/x-matroska',
   'mka': 'audio/x-matroska',
   'mkd': 'text/x-web-markdown',


### PR DESCRIPTION
Wasm support in Flutter is based on "mjs" file to load the "wasm" file. I've tried to publish Web assembly via Alfred, which relies on your package, but "mjs" files were blocked because of the lack of proper MIME type for this extension.